### PR TITLE
Lazy Init PQ Metrics

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -578,8 +578,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
         final IRubyObject retrievedMetric = collector.callMethod(context, "get", new IRubyObject[]{fullNamespace, metricName, context.runtime.newSymbol("gauge")});
 
         LazyDelegatingGauge delegatingGauge = retrievedMetric.toJava(LazyDelegatingGauge.class);
-        if (Objects.isNull(delegatingGauge.getType()) ||
-                MetricType.GAUGE_NUMBER.asString().equals(delegatingGauge.getType().asString()) == false) {
+        if (Objects.isNull(delegatingGauge.getType()) || delegatingGauge.getType() != MetricType.GAUGE_NUMBER) {
             return Optional.empty();
         }
 

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -42,9 +42,9 @@ public interface FlowMetric extends Metric<Map<String,Double>> {
         }
     }
 
-    static <N extends Number, D extends Number> FlowMetric create(final String name,
-                                                                  final Supplier<Metric<N>> numeratorSupplier,
-                                                                  final Supplier<Metric<D>> denominatorSupplier) {
-        return new LazyInstantiatedFlowMetric<>(name, numeratorSupplier, denominatorSupplier);
+    static FlowMetric create(final String name,
+                             final Supplier<? extends Metric<? extends Number>> numeratorSupplier,
+                             final Supplier<? extends Metric<? extends Number>> denominatorSupplier) {
+        return new LazyInstantiatedFlowMetric(name, numeratorSupplier, denominatorSupplier);
     }
 }


### PR DESCRIPTION
This series is PR-review for elastic/logstash#14554 and includes a minor refactor of the `LazyInstantiatedFlowMetric` introduced in elastic/logstash#14571 to reduce the pre-casting necessary to create a lazily-initialized flow metric.

 - Previously required `Supplier<Metric<N>>` and `Supplier<Metric<D>>` where `N` and `D` were separately-defined as  `N extends Number` and `D extends Number` respectively. This _significantly_ complicated the call-site, because a `Supplier<NumberGauge>` or a `Supplier<UptimeMetric::ScaledView>` needed to be pre-cast to `Supplier<Metric<Number>>` and `Supplier<Metric<Number>>` .
 - now both numerator and denominator require a `Supplier<? extends Metric<? extends Number>>`, which looks a little more complicated on its face but effectively means providing a `Supplier<NumberGauge>` or `Supplier<UptimeMetric::ScaledView>` _just works_.