### PR TITLE
Flow metrics pq in pipeline namespace

### DIFF
--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -39,7 +39,6 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -528,17 +527,16 @@ public class AbstractPipelineExt extends RubyBasicObject {
 
             final RubySymbol[] queueNamespace = buildNamespace(QUEUE_KEY);
             final RubySymbol[] queueCapacityNamespace = buildNamespace(QUEUE_KEY, CAPACITY_KEY);
-            final RubySymbol[] queueFlowNamespace = buildNamespace(QUEUE_KEY, FLOW_KEY);
 
             final Supplier<NumberGauge> eventsGaugeMetricSupplier = () -> initOrGetNumberGaugeMetric(context, queueNamespace, EVENTS_KEY).orElse(null);
-            final FlowMetric growthEventsFlow = createFlowMetric(QUEUE_GROWTH_EVENTS_KEY, eventsGaugeMetricSupplier, () -> uptimeInPreciseSeconds);
+            final FlowMetric growthEventsFlow = createFlowMetric(QUEUE_PERSISTED_GROWTH_EVENTS_KEY, eventsGaugeMetricSupplier, () -> uptimeInPreciseSeconds);
             this.flowMetrics.add(growthEventsFlow);
-            storeMetric(context, queueFlowNamespace, growthEventsFlow);
+            storeMetric(context, flowNamespace, growthEventsFlow);
 
             final Supplier<NumberGauge> queueSizeInBytesMetricSupplier = () -> initOrGetNumberGaugeMetric(context, queueCapacityNamespace, QUEUE_SIZE_IN_BYTES_KEY).orElse(null);
-            final FlowMetric growthBytesFlow = createFlowMetric(QUEUE_GROWTH_BYTES_KEY, queueSizeInBytesMetricSupplier, () -> uptimeInPreciseSeconds);
+            final FlowMetric growthBytesFlow = createFlowMetric(QUEUE_PERSISTED_GROWTH_BYTES_KEY, queueSizeInBytesMetricSupplier, () -> uptimeInPreciseSeconds);
             this.flowMetrics.add(growthBytesFlow);
-            storeMetric(context, queueFlowNamespace, growthBytesFlow);
+            storeMetric(context, flowNamespace, growthBytesFlow);
         }
         return context.nil;
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/LazyInstantiatedFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/LazyInstantiatedFlowMetric.java
@@ -17,11 +17,9 @@ import java.util.function.Supplier;
  *
  * @see FlowMetric#create(String, Supplier, Supplier)
  */
-public class LazyInstantiatedFlowMetric implements FlowMetric {
+public class LazyInstantiatedFlowMetric extends AbstractMetric<Map<String, Double>> implements FlowMetric {
 
     static final Logger LOGGER = LogManager.getLogger(LazyInstantiatedFlowMetric.class);
-
-    private final String name;
 
     private final AtomicReference<Supplier<? extends Metric<? extends Number>>> numeratorSupplier;
     private final AtomicReference<Supplier<? extends Metric<? extends Number>>> denominatorSupplier;
@@ -33,7 +31,7 @@ public class LazyInstantiatedFlowMetric implements FlowMetric {
     LazyInstantiatedFlowMetric(final String name,
                                final Supplier<? extends Metric<? extends Number>> numeratorSupplier,
                                final Supplier<? extends Metric<? extends Number>> denominatorSupplier) {
-        this.name = name;
+        super(name);
         this.numeratorSupplier = new AtomicReference<>(numeratorSupplier);
         this.denominatorSupplier = new AtomicReference<>(denominatorSupplier);
     }
@@ -41,11 +39,6 @@ public class LazyInstantiatedFlowMetric implements FlowMetric {
     @Override
     public void capture() {
         getInner().ifPresentOrElse(FlowMetric::capture, this::warnNotInitialized);
-    }
-
-    @Override
-    public String getName() {
-        return this.name;
     }
 
     @Override

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/MetricKeys.java
@@ -96,7 +96,7 @@ public final class MetricKeys {
 
     public static final RubySymbol UPTIME_IN_MILLIS_KEY = RubyUtil.RUBY.newSymbol("uptime_in_millis");
 
-    public static final RubySymbol QUEUE_GROWTH_EVENTS_KEY = RubyUtil.RUBY.newSymbol("growth_events");
+    public static final RubySymbol QUEUE_PERSISTED_GROWTH_EVENTS_KEY = RubyUtil.RUBY.newSymbol("queue_persisted_growth_events");
 
-    public static final RubySymbol QUEUE_GROWTH_BYTES_KEY = RubyUtil.RUBY.newSymbol("growth_bytes");
+    public static final RubySymbol QUEUE_PERSISTED_GROWTH_BYTES_KEY = RubyUtil.RUBY.newSymbol("queue_persisted_growth_bytes");
 }

--- a/qa/integration/specs/monitoring_api_spec.rb
+++ b/qa/integration/specs/monitoring_api_spec.rb
@@ -190,12 +190,6 @@ describe "Test Monitoring API" do
         expect(queue_capacity_stats["page_capacity_in_bytes"]).not_to be_nil
         expect(queue_capacity_stats["max_queue_size_in_bytes"]).not_to be_nil
         expect(queue_capacity_stats["max_unread_events"]).not_to be_nil
-
-        queue_flow_stats = queue_stats.dig("flow")
-        expect(queue_flow_stats).to_not be_nil
-        expect(queue_flow_stats).to include(
-                                 'growth_bytes' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0),
-                                 'growth_events' => hash_including('current' => a_value >= 0, 'lifetime' => a_value >= 0))
       else
         expect(queue_stats["type"]).to eq("memory")
       end
@@ -280,6 +274,15 @@ describe "Test Monitoring API" do
         'filter_throughput'  => hash_including('current' => a_value >= 0, 'lifetime' => a_value >  0),
         'output_throughput'  => hash_including('current' => a_value >= 0, 'lifetime' => a_value >  0)
       )
+      if logstash_service.settings.feature_flag == "persistent_queues"
+        expect(flow_status).to include(
+                                 'queue_persisted_growth_bytes'  => hash_including('current' => a_kind_of(Number), 'lifetime' => a_kind_of(Number)),
+                                 'queue_persisted_growth_events' => hash_including('current' => a_kind_of(Number), 'lifetime' => a_kind_of(Number))
+                               )
+      else
+        expect(flow_status).to_not include('queue_persisted_growth_bytes')
+        expect(flow_status).to_not include('queue_persisted_growth_events')
+      end
     end
   end
 


### PR DESCRIPTION
1. Make our `LazyInstantiatedFlowMetric` extend `AbstractMetric<>` so that we can get its serialization annotations
2. Move our pipeline-level metrics for persistent queues up to the pipeline flow namespace.